### PR TITLE
Fixed bug where setting token was failing on first run

### DIFF
--- a/src/infrastructure/configuration.rs
+++ b/src/infrastructure/configuration.rs
@@ -124,10 +124,10 @@ impl Configuration {
 
     fn write_to_file(self) -> Result<(), ConfigurationError> {
         let toml_string = toml::to_string(&self)?;
-        std::fs::write(
-            Self::get_project_directories().config_dir().join(".config"),
-            toml_string,
-        )?;
+        let project_dirs = Self::get_project_directories();
+        let config_dir = project_dirs.config_dir();
+        std::fs::create_dir_all(config_dir)?;
+        std::fs::write(config_dir.join(".config"), toml_string)?;
         Ok(())
     }
 }

--- a/src/infrastructure/configuration.rs
+++ b/src/infrastructure/configuration.rs
@@ -142,7 +142,9 @@ mod tests {
         let project_dirs = Configuration::get_project_directories();
         let config_dir = project_dirs.config_dir();
         std::fs::remove_dir_all(config_dir).ok();
-        let result =  Configuration::default().write_to_file();
+        assert!(!config_dir.exists()); // sanity check
+
+        let result = Configuration::default().write_to_file();
         assert!(result.is_ok());
         assert!(config_dir.exists());
     }

--- a/src/infrastructure/configuration.rs
+++ b/src/infrastructure/configuration.rs
@@ -131,3 +131,19 @@ impl Configuration {
         Ok(())
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The default configuration should be writable when the project dir doesn't exist yet.
+    #[test]
+    fn write_default_configuration_before_project_dir_exists() {
+        let project_dirs = Configuration::get_project_directories();
+        let config_dir = project_dirs.config_dir();
+        std::fs::remove_dir_all(config_dir).ok();
+        let result =  Configuration::default().write_to_file();
+        assert!(result.is_ok());
+        assert!(config_dir.exists());
+    }
+}


### PR DESCRIPTION
Hello, thanks for the making this tool!

On first run to set the token, I was getting an error that it could not create a configuration file. Debugging it, it yielded this underlying io error: `Os { code: 2, kind: NotFound, message: "No such file or directory" }` at https://github.com/kpagacz/elv/blob/7edf050b572c6fab0670098f2493eb1a8970d8de/src/infrastructure/configuration.rs#L127-L130

I added a unit test that confirms the new behavior. Hope that's okay!